### PR TITLE
1.0.15.tf cod (#76)

### DIFF
--- a/ipa.tf
+++ b/ipa.tf
@@ -48,11 +48,6 @@ locals {
   ] : []
   storage_spec = var.include_fsx == true ? local.fsx_values : local.efs_values
   acm_ipa_values = var.use_acm == true ? (<<EOT
-runtime-scanner:
-  enabled: ${replace(lower(var.aws_account), "indico", "") == lower(var.aws_account) ? "false" : "true"}
-  authentication:
-    ingressUser: monitoring
-    ingressPassword: ${random_password.monitoring-password.result}
 app-edge:
   service:
     type: "NodePort"


### PR DESCRIPTION
* Fixed bad merge

* Converted to helm plugin

* Converted to helm plugin

* Updated to use the actual account name

* Updated to use the actual account name

* Updated to use the actual account name

* Updated the domain to be closer to our aws model

* Added admin_group_name

* Added admin_group_name

* Fixed variable names

* [DOP-1363] allow using ALB instead of ELB. (#30)

* [dop-1363] Pass in values for ACM if in use.

* [dop-1363] fix variable name -dns_name

* [dop-1363] adjust how public subnets are passed in.

* [dop-1363] adjust how public subnets are passed in ... again

* [dop-1363] adjust how public subnets are passed in ... try join

* [dop-1363] adjust how block is passed.

* [dop-1363] fix CAA records. Also use the correct argo application.

* [dop-1363] Create alb values file. Add dependencies on acm.

* [dop-1363] fix syntax

* [dop-1363] adjust indenting.

* [dop-1363] adjust indenting... again

* [dop-1363] adjust indenting... again ... using indent function.

* [dop-1363] Update to indico-aws-eks-cluster 7.2.2

* [dop-1363] Reference the correct argo plugin.

* Added support for k8s dashboard chart (#31)

* Added support for k8s dashboard chart

* Added support for k8s dashboard chart

* Update variables.tf

* [DOP-1363] Fix content error (#33)

* [dop-1363] Pass in values for ACM if in use.

* [dop-1363] fix variable name -dns_name

* [dop-1363] adjust how public subnets are passed in.

* [dop-1363] adjust how public subnets are passed in ... again

* [dop-1363] adjust how public subnets are passed in ... try join

* [dop-1363] adjust how block is passed.

* [dop-1363] fix CAA records. Also use the correct argo application.

* [dop-1363] Create alb values file. Add dependencies on acm.

* [dop-1363] fix syntax

* [dop-1363] adjust indenting.

* [dop-1363] adjust indenting... again

* [dop-1363] adjust indenting... again ... using indent function.

* [dop-1363] Update to indico-aws-eks-cluster 7.2.2

* [dop-1363] Reference the correct argo plugin.

* [dop-1363] Add valid content if acm is not used.

* Use fqdn for dashboard url

* Integrate keycloak (#36)

* Add keycloak client

* Remove bad flag

* Remove bad flag

* Remove bad flag

* Remove bad flag

* Remove bad flag

* Remove bad flag

* Remove bad flag

* Enable standard flow

* Use dynamic client/secret

* Add modules (#37)

* Remove file from bad merge

* Fast s3 delete (#40)

* Speedup deletion of s3 buckets

* Speedup deletion of s3 buckets

* Speedup deletion of s3 buckets

* Speedup deletion of s3 buckets

* Speedup deletion of s3 buckets

* fixed merge

* Fast s3 delete (#41)

* Speedup deletion of s3 buckets

* Speedup deletion of s3 buckets

* Speedup deletion of s3 buckets

* Speedup deletion of s3 buckets

* Speedup deletion of s3 buckets

* fixed merge

* Get bucket name from the module

* Fixed account ref for Azure

* Fixed indent for apps

* Specify RG name for azure dns

* Added snapshot workload identity permissions (#44)

Co-authored-by: ashmuck <andrey.chmykh@indico.io>

* Added missing var

* Remove location

* Added snapshot workload identity permissions (#45)

Co-authored-by: ashmuck <andrey.chmykh@indico.io>

* Use indico-common for Azure DNS

* [DOP-1363] fix issue with app-edge certificate (#42)

* [DOP-1363] Add correct annotations and also tls section for ingress.

* [DOP-1363] removed annotations from override in favor of suppling them directly in the chart.

* [DOP-1363] Add annotations back for use with zerossl.

* [DOP-1363] Deploy aws-load-balancer-controller from ipa-pre-requisites and have the ingress created during the ipa install. This is to help with cleanup when tearing down a cluster.

* Fix azure snapshots (#46)

* Added github provider

* Added github provider

* Add workload identity for cod-snapshots

* Output the workload identity

* Use the snapshot restore chart

* Fixed reference to cod-snapshot-restore

* Updated default for common_reesource_group

* Fixed reference to cod-snapshot-restore

* Use common resource group name

* Cleanup and clearer dependencies

* Fixed the values

* Enable tcm to get secret from the cluster itself

* Enable tcm to get secret from the cluster itself

* Added a namespace

* Made some of the snapshot items not conditional, we want to be able to save snapshot regardless of whether we restore snapshot

* Use the workload identity as a secret

* Use the azure version of the snapshot container

* Added tenant-id service account annotation

* Document where these annotations come from

* Removed old comments

* Pass the snapshot name into the helm chart

* Increase CRD timeout and added missing annotation

* Fixed snapshot dependency

* Fixed snapshot SA account name

* Pass storage account name into helm chart for azure save/restore

Co-authored-by: ashmuck <andrey.chmykh@indico.io>

* merge latest changes from 1.0.15 branch

* [DOP-1307] Security Enhancements (#28)

* [DOP-1307] require the use of IMDSv2 by updating the  metadata options for nodes.

* [DOP-1307] Update public networking to 1.2.0, which will modify the default security group to restrict ingress / egress traffic.

* [dop-1363] allow acm to be used to manage certificates if needed.

* [dop-1363] create output for acm

* [dop-1363] add more CAA records.

* [dop-1363] Use alternative method for creating acm.

* [dop-1363] Remove extra code

* [dop-1363] Remove count

* [dop-1363] Fix name for aws_acm_certificate_validation resource.

* [dop-1363] Rmove reference to count index

* [DOP-1307] Use Correct version of indico-aws-eks-cluster module.

* [DOP-1363] Only install aws-load-balancer-controller if acm is being used. (#48)

* Update main.tf (#52)

* polarity was backwards for sns_sqs

* update azure aks to 1.23.12

* Added engineering group as admins

* Add the engineering team to cluster admins for COD

* Use 1.23.15 for k8s

* undo engineering for admins on azure

* undo engineering for admins on azure

* Add engineering group to admins

* use engineering group for admins on azure

* Add support for external accounts (#56)

* Make github resources conditional

* No need to override

* Added support for customer accounts

* Updated default value, now have to slightly update the charts repo

* Pass KUBE_VERSION env.var (#58)

* 1.0.15.1 (#59)

* Make github resources conditional

* No need to override

* Added support for customer accounts

* Add helm values

* Fixed bad Rakefile merge

* Cleanup Rakefile

* undo mistake with typo

* undo bad merge

* Added in mount options

* Added Gemfile for Azure installs

* use pyhcl instead of openstruct

* Bump argo version to handle 2.23x k8s clusters

* [DOP-1271] (#62)

* [DOP-1271] Update eks version to 1.23 by default.

* [DOP-1271] fix smoketest values

* Merge latest from 1.0.15

* [DOP-1271] fix bad merge with depends_on

* [DOP-1271] fix bad merge remove acm duplicates

* [DOP-1271] try updating to eks 1.24

* [DOP-1271] Update to the latest argocd provider.

* [DOP-1271] Update to the latest argocd provider in aws.

* [DOP-1271] revert provider for argocd.

* [DOP-1271] change to latestindico-argo-registration version

* [DOP-1271] add required fields

* [DOP-1271] use updated argo reference to create the secret.

* [DOP-1271] Set eks default version to 1.23. This will ensure an easier update path for existing clusters. 1.24 has been tested as working.

* Make mapping of AD group optional

* Make mapping of AD group optional (#63)

* Fixed bad merge

* Fixed conflict

* Update ipa.tf

* Update user_vars.auto.tfvars (#65)

Set eks to default to 1.24.

* Patch azure custom application definition (#70)

* Correct azure custom applications (#68)

* 1.0.15.include rt (#71)

* Delete Rakefile

* Delete Gemfile

* merge 1.0.15 into IPA-6.0.0.rc (#73)

* Make mapping of AD group optional (#63)

* Correct azure custom applications (#68)

* 1.0.15.include rt (#71)

* Delete Rakefile

* Delete Gemfile

* Simply passing in runtime-scanner for azure as well

* Remove redundant runtimescanner

Co-authored-by: ashmuck <andrey.chmykh@indico.io>
Co-authored-by: Nathan Okolita <Nathan.Okolita@gmail.com>
Co-authored-by: Andrey Chmykh <90482061+ashmuck@users.noreply.github.com>

[DOP-1363]: https://indicodata.atlassian.net/browse/DOP-1363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ