### PR TITLE
[DOP-1473]

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -250,7 +250,7 @@ module "cluster" {
   aws_account_name           = var.aws_account
   oidc_enabled               = false
   source                     = "app.terraform.io/indico/indico-aws-eks-cluster/mod"
-  version                    = "7.5.0"
+  version                    = "7.6.0"
   label                      = var.label
   additional_tags            = var.additional_tags
   region                     = var.region

--- a/main.tf
+++ b/main.tf
@@ -250,7 +250,7 @@ module "cluster" {
   aws_account_name           = var.aws_account
   oidc_enabled               = false
   source                     = "app.terraform.io/indico/indico-aws-eks-cluster/mod"
-  version                    = "7.4.0"
+  version                    = "7.5.0"
   label                      = var.label
   additional_tags            = var.additional_tags
   region                     = var.region


### PR DESCRIPTION
- Do not install aws-ebs-csi-driver as an eks add-on.