### PR TITLE
Remove cluster manager in cluster-on-demand

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -136,7 +136,7 @@ module "sqs_sns" {
   region  = var.region
   label   = var.label
 }
-
+/*
 module "cluster-manager" {
   source                   = "app.terraform.io/indico/indico-aws-cluster-manager/mod"
   version                  = "1.1.1"
@@ -153,7 +153,7 @@ module "cluster-manager" {
   kms_key_arn              = module.kms_key.key_arn
   assumed_roles            = var.assumed_roles
 }
-
+*/
 module "kms_key" {
   source          = "app.terraform.io/indico/indico-aws-kms/mod"
   version         = "1.1.0"

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,12 +8,12 @@ output "data_s3_bucket_name" {
   description = "Name of the data s3 bucket"
   value       = module.s3-storage.data_s3_bucket_name
 }
-
+/*
 output "cluster_manager_ip" {
   description = "IP of the cluster manager instance"
   value       = module.cluster-manager.cluster_manager_ip
 }
-
+*/
 
 output "s3_role_id" {
   description = "ID of the S3 role"


### PR DESCRIPTION
It's starting to raise errors, and if we want some sort of cluster manager we should consider constructing a new image/making a plan for the cluster manager