### PR TITLE
Dns resolver label 620

### DIFF
--- a/azure/ipa.tf
+++ b/azure/ipa.tf
@@ -555,6 +555,10 @@ spec:
               authentication:
                 ingressUser: monitoring
                 ingressPassword: ${random_password.monitoring-password.result}
+              ingress: 
+                useDefaultResolver: false
+                labels:
+                  acme.cert-manager.io/dns01-solver: "true"
         
         - name: HELM_VALUES
           value: |

--- a/azure/monitoring.tf
+++ b/azure/monitoring.tf
@@ -112,6 +112,17 @@ resource "helm_release" "monitoring" {
           volumeClaimTemplate:
             spec:
               storageClassName: default
+      ingress:
+        labels:
+          acme.cert-manager.io/dns01-solver: "true"
+    grafana:
+      ingress:
+        labels:
+          acme.cert-manager.io/dns01-solver: "true"
+    alertmanager:
+      ingress:
+        labels:
+          acme.cert-manager.io/dns01-solver: "true"
 
   prometheus-adapter:
     enabled: false

--- a/azure/monitoring.tf
+++ b/azure/monitoring.tf
@@ -104,6 +104,8 @@ resource "helm_release" "monitoring" {
 
   kube-prometheus-stack:
     enabled: ${local.kube_prometheus_stack_enabled}
+    commonLabels:
+      acme.cert-manager.io/dns01-solver: "true"
     prometheus:
       prometheusSpec:
         nodeSelector:
@@ -113,16 +115,15 @@ resource "helm_release" "monitoring" {
             spec:
               storageClassName: default
       ingress:
-        labels:
-          acme.cert-manager.io/dns01-solver: "true"
+        labels: null
     grafana:
       ingress:
-        labels:
-          acme.cert-manager.io/dns01-solver: "true"
+        labels: null
+      extraLabels: 
+        acme.cert-manager.io/dns01-solver: "true"
     alertmanager:
       ingress:
-        labels:
-          acme.cert-manager.io/dns01-solver: "true"
+        labels: null
 
   prometheus-adapter:
     enabled: false

--- a/azure/openshift/infrastructure/monitoring.tf
+++ b/azure/openshift/infrastructure/monitoring.tf
@@ -141,7 +141,8 @@ resource "helm_release" "monitoring" {
     enabled: true
     nodeExporter:
       enabled: false
-
+    commonLabels:
+      acme.cert-manager.io/dns01-solver: "true"
     prometheus:
       enabled: true
       prometheusSpec:
@@ -152,16 +153,15 @@ resource "helm_release" "monitoring" {
             spec:
               storageClassName: default
       ingress:
-        labels:
-          acme.cert-manager.io/dns01-solver: "true"
+        labels: null
     grafana:
       ingress:
-        labels:
-          acme.cert-manager.io/dns01-solver: "true"
+        labels: null
+      extraLabels: 
+        acme.cert-manager.io/dns01-solver: "true"
     alertmanager:
       ingress:
-        labels:
-          acme.cert-manager.io/dns01-solver: "true"
+        labels: null
 
   prometheus-adapter:
     enabled: false

--- a/azure/openshift/infrastructure/monitoring.tf
+++ b/azure/openshift/infrastructure/monitoring.tf
@@ -151,6 +151,17 @@ resource "helm_release" "monitoring" {
           volumeClaimTemplate:
             spec:
               storageClassName: default
+      ingress:
+        labels:
+          acme.cert-manager.io/dns01-solver: "true"
+    grafana:
+      ingress:
+        labels:
+          acme.cert-manager.io/dns01-solver: "true"
+    alertmanager:
+      ingress:
+        labels:
+          acme.cert-manager.io/dns01-solver: "true"
 
   prometheus-adapter:
     enabled: false

--- a/azure/openshift/ipa/ipa.tf
+++ b/azure/openshift/ipa/ipa.tf
@@ -107,6 +107,10 @@ spec:
               authentication:
                 ingressUser: ${var.monitoring_username}
                 ingressPassword: ${var.monitoring_password}
+              ingress: 
+                useDefaultResolver: false
+                labels:
+                  acme.cert-manager.io/dns01-solver: "true"
         
         - name: HELM_VALUES
           value: |

--- a/ipa.tf
+++ b/ipa.tf
@@ -67,8 +67,10 @@ app-edge:
     ingress:
       enabled: true
       annotations:
-        acme.cert-manager.io/http01-edit-in-place: "true"
-        cert-manager.io/cluster-issuer: zerossl      
+        cert-manager.io/cluster-issuer: zerossl
+      useDefaultResolver: false
+      labels:
+        acme.cert-manager.io/dns01-solver: "true"
       tls:
         - secretName: indico-ssl-cm-cert
           hosts:
@@ -707,6 +709,10 @@ spec:
               authentication:
                 ingressUser: monitoring
                 ingressPassword: ${random_password.monitoring-password.result}
+              ingress: 
+                useDefaultResolver: false
+                labels:
+                  acme.cert-manager.io/dns01-solver: "true"
             ${indent(12, local.acm_ipa_values)}         
 
         - name: HELM_VALUES

--- a/monitoring.tf
+++ b/monitoring.tf
@@ -104,7 +104,8 @@ resource "helm_release" "monitoring" {
     grafana:
       ingress: 
         labels: null
-      extraLabels: acme.cert-manager.io/dns01-solver: "true"
+      extraLabels: 
+        acme.cert-manager.io/dns01-solver: "true"
     alertmanager:
       ingress: 
         labels: null

--- a/monitoring.tf
+++ b/monitoring.tf
@@ -100,11 +100,14 @@ resource "helm_release" "monitoring" {
       prometheusSpec:
         nodeSelector:
           node_group: static-workers
-      ingress: null
+      ingress:
+        labels: null
     grafana:
-      ingress: null
+      ingress: 
+        labels: null
     alertmanager:
-      ingress: null
+      ingress: 
+        labels: null
 
  EOF
   ]

--- a/monitoring.tf
+++ b/monitoring.tf
@@ -71,23 +71,13 @@ resource "helm_release" "monitoring" {
   wait             = false
   timeout          = "900" # 15 minutes
 
-  values = [<<FONE
-  kube-prometheus-stack:
-    prometheus:
-      ingress:
-        labels: null
-    grafana:
-      ingress:
-        labels: null
-    alertmanager:
-      ingress:
-        labels: null
-  FONE 
-    ,
-    <<FTWO
+  values = [<<EOF
   global:
     host: "${local.dns_name}"
   
+  commonLabels:
+    acme.cert-manager.io/dns01-solver: "true"
+
   ingress-nginx:
     enabled: true
 
@@ -110,19 +100,13 @@ resource "helm_release" "monitoring" {
       prometheusSpec:
         nodeSelector:
           node_group: static-workers
-      ingress:
-        labels:
-          acme.cert-manager.io/dns01-solver: "true"
+      ingress: null
     grafana:
-      ingress:
-        labels:
-          acme.cert-manager.io/dns01-solver: "true"
+      ingress: null
     alertmanager:
-      ingress:
-        labels:
-          acme.cert-manager.io/dns01-solver: "true"
+      ingress: null
 
- FTWO
+ EOF
   ]
 }
 

--- a/monitoring.tf
+++ b/monitoring.tf
@@ -74,9 +74,6 @@ resource "helm_release" "monitoring" {
   values = [<<EOF
   global:
     host: "${local.dns_name}"
-  
-  commonLabels:
-    acme.cert-manager.io/dns01-solver: "true"
 
   ingress-nginx:
     enabled: true
@@ -96,6 +93,8 @@ resource "helm_release" "monitoring" {
     ingressPassword: ${random_password.monitoring-password.result}
 
   kube-prometheus-stack:
+    commonLabels:
+      acme.cert-manager.io/dns01-solver: "true"
     prometheus:
       prometheusSpec:
         nodeSelector:

--- a/monitoring.tf
+++ b/monitoring.tf
@@ -98,14 +98,17 @@ resource "helm_release" "monitoring" {
         nodeSelector:
           node_group: static-workers
       ingress:
+        labels: {}
         labels:
           acme.cert-manager.io/dns01-solver: "true"
     grafana:
       ingress:
+        labels: {}
         labels:
           acme.cert-manager.io/dns01-solver: "true"
     alertmanager:
       ingress:
+        labels: {}
         labels:
           acme.cert-manager.io/dns01-solver: "true"
 

--- a/monitoring.tf
+++ b/monitoring.tf
@@ -75,13 +75,13 @@ resource "helm_release" "monitoring" {
   kube-prometheus-stack:
     prometheus:
       ingress:
-        labels: 
+        labels: null
     grafana:
       ingress:
-        labels: {}
+        labels: null
     alertmanager:
       ingress:
-        labels: {}
+        labels: null
   FONE 
     ,
     <<FTWO

--- a/monitoring.tf
+++ b/monitoring.tf
@@ -72,6 +72,17 @@ resource "helm_release" "monitoring" {
   timeout          = "900" # 15 minutes
 
   values = [<<EOF
+  kube-prometheus-stack:
+    prometheus:
+      ingress:
+        labels: {}
+    grafana:
+      ingress:
+        labels: {}
+    alertmanager:
+      ingress:
+        labels: {}
+  EOF  ,<<EOF
   global:
     host: "${local.dns_name}"
   
@@ -98,17 +109,14 @@ resource "helm_release" "monitoring" {
         nodeSelector:
           node_group: static-workers
       ingress:
-        labels: {}
         labels:
           acme.cert-manager.io/dns01-solver: "true"
     grafana:
       ingress:
-        labels: {}
         labels:
           acme.cert-manager.io/dns01-solver: "true"
     alertmanager:
       ingress:
-        labels: {}
         labels:
           acme.cert-manager.io/dns01-solver: "true"
 

--- a/monitoring.tf
+++ b/monitoring.tf
@@ -97,6 +97,17 @@ resource "helm_release" "monitoring" {
       prometheusSpec:
         nodeSelector:
           node_group: static-workers
+      ingress:
+        labels:
+          acme.cert-manager.io/dns01-solver: "true"
+    grafana:
+      ingress:
+        labels:
+          acme.cert-manager.io/dns01-solver: "true"
+    alertmanager:
+      ingress:
+        labels:
+          acme.cert-manager.io/dns01-solver: "true"
 
  EOF
   ]

--- a/monitoring.tf
+++ b/monitoring.tf
@@ -71,7 +71,7 @@ resource "helm_release" "monitoring" {
   wait             = false
   timeout          = "900" # 15 minutes
 
-  values = [<<EOF
+  values = [<<FONE
   kube-prometheus-stack:
     prometheus:
       ingress:
@@ -82,7 +82,8 @@ resource "helm_release" "monitoring" {
     alertmanager:
       ingress:
         labels: {}
-  EOF  ,<<EOF
+  FONE
+    , <<FTWO
   global:
     host: "${local.dns_name}"
   
@@ -120,7 +121,7 @@ resource "helm_release" "monitoring" {
         labels:
           acme.cert-manager.io/dns01-solver: "true"
 
- EOF
+ FTWO
   ]
 }
 

--- a/monitoring.tf
+++ b/monitoring.tf
@@ -104,6 +104,7 @@ resource "helm_release" "monitoring" {
     grafana:
       ingress: 
         labels: null
+      extraLabels: acme.cert-manager.io/dns01-solver: "true"
     alertmanager:
       ingress: 
         labels: null

--- a/monitoring.tf
+++ b/monitoring.tf
@@ -75,15 +75,16 @@ resource "helm_release" "monitoring" {
   kube-prometheus-stack:
     prometheus:
       ingress:
-        labels: {}
+        labels: 
     grafana:
       ingress:
         labels: {}
     alertmanager:
       ingress:
         labels: {}
-  FONE
-    , <<FTWO
+  FONE 
+    ,
+    <<FTWO
   global:
     host: "${local.dns_name}"
   


### PR DESCRIPTION
This replaces the default http01-resolver labels in all of our helm charts with dns01-resolver labels

These changes need to also be merged to main and pushed to IPA-6.1.1