### PR TITLE
[DOP-1647] remove hard-coded smoketest values

### DIFF
--- a/ipa.tf
+++ b/ipa.tf
@@ -622,18 +622,11 @@ spec:
       
         - name: HELM_VALUES
           value: |
-            image:
-              tag: ${var.ipa_smoketest_container_tag}
-            cronjob:
-              enabled: ${var.ipa_smoketest_cronjob_enabled}
-              schedule: "${var.ipa_smoketest_cronjob_schedule}"
             cluster:
               name: ${var.label}
               region: ${var.region}
               account: ${var.aws_account}
             host: ${local.dns_name}
-            slack:
-              channel: ${var.ipa_smoketest_slack_channel}
             ${indent(12, base64decode(var.ipa_smoketest_values))}    
 EOT
 }

--- a/variables.tf
+++ b/variables.tf
@@ -325,34 +325,14 @@ variable "ipa_smoketest_repo" {
   default = "https://harbor.devops.indico.io/chartrepo/indico-charts"
 }
 
-variable "ipa_smoketest_container_tag" {
-  type    = string
-  default = "IPA-5.4-e1c5af3d"
-}
-
 variable "ipa_smoketest_version" {
   type    = string
   default = "0.1.8"
 }
 
-variable "ipa_smoketest_slack_channel" {
-  type    = string
-  default = "cod-smoketest-results"
-}
-
 variable "ipa_smoketest_enabled" {
   type    = bool
   default = true
-}
-
-variable "ipa_smoketest_cronjob_enabled" {
-  type    = bool
-  default = false
-}
-
-variable "ipa_smoketest_cronjob_schedule" {
-  type    = string
-  default = "0 0 * * *" # every night at midnight
 }
 
 variable "monitoring_version" {


### PR DESCRIPTION
Remove smoketest values in tf_cod if those values are specified in the chart. This prevents duplicates being written to ipa_smoketest.yaml. Duplicates cause an error when the structure of the file is validated when force updating with cluster-on-demand.

This fix will also need to be applied for Azure and Openshift when it is possible to verify the fix on those clusters from the main terraform branch.

The failed checks are for the azure and openshift clusters that did not come up correctly due to other issues filed separately.