### PR TITLE
[DOP-1801][DOP-1742] Spot fix

### DIFF
--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -305,7 +305,7 @@ variable "monitoring_enabled" {
 
 variable "keda_version" {
   type        = string
-  default     = "2.8.1"
+  default     = "2.11.2"
   description = "Version of keda helm chart"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -276,7 +276,7 @@ module "cluster" {
   aws_account_name           = var.aws_account
   oidc_enabled               = false
   source                     = "app.terraform.io/indico/indico-aws-eks-cluster/mod"
-  version                    = "8.0.0"
+  version                    = "8.0.1"
   label                      = var.label
   additional_tags            = var.additional_tags
   region                     = var.region

--- a/main.tf
+++ b/main.tf
@@ -276,7 +276,7 @@ module "cluster" {
   aws_account_name           = var.aws_account
   oidc_enabled               = false
   source                     = "app.terraform.io/indico/indico-aws-eks-cluster/mod"
-  version                    = "8.0.3"
+  version                    = "8.0.4"
   label                      = var.label
   additional_tags            = var.additional_tags
   region                     = var.region

--- a/main.tf
+++ b/main.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.38.0"
+      version = "~> 5.14.0"
     }
     time = {
       source  = "hashicorp/time"
-      version = "0.7.2"
+      version = "0.9.1"
     }
     keycloak = {
       source  = "mrparkers/keycloak"

--- a/main.tf
+++ b/main.tf
@@ -276,7 +276,7 @@ module "cluster" {
   aws_account_name           = var.aws_account
   oidc_enabled               = false
   source                     = "app.terraform.io/indico/indico-aws-eks-cluster/mod"
-  version                    = "8.0.5"
+  version                    = "8.0.6"
   label                      = var.label
   additional_tags            = var.additional_tags
   region                     = var.region

--- a/main.tf
+++ b/main.tf
@@ -258,7 +258,7 @@ module "cluster" {
   aws_account_name           = var.aws_account
   oidc_enabled               = false
   source                     = "app.terraform.io/indico/indico-aws-eks-cluster/mod"
-  version                    = "8.0.19"
+  version                    = "8.0.20"
   label                      = var.label
   additional_tags            = var.additional_tags
   region                     = var.region

--- a/main.tf
+++ b/main.tf
@@ -275,7 +275,7 @@ module "cluster" {
   aws_account_name           = var.aws_account
   oidc_enabled               = false
   source                     = "app.terraform.io/indico/indico-aws-eks-cluster/mod"
-  version                    = "7.8.0"
+  version                    = "8.0.0"
   label                      = var.label
   additional_tags            = var.additional_tags
   region                     = var.region

--- a/main.tf
+++ b/main.tf
@@ -275,7 +275,7 @@ module "cluster" {
   aws_account_name           = var.aws_account
   oidc_enabled               = false
   source                     = "app.terraform.io/indico/indico-aws-eks-cluster/mod"
-  version                    = "8.0.16"
+  version                    = "8.0.17"
   label                      = var.label
   additional_tags            = var.additional_tags
   region                     = var.region

--- a/main.tf
+++ b/main.tf
@@ -276,7 +276,7 @@ module "cluster" {
   aws_account_name           = var.aws_account
   oidc_enabled               = false
   source                     = "app.terraform.io/indico/indico-aws-eks-cluster/mod"
-  version                    = "8.0.4"
+  version                    = "8.0.5"
   label                      = var.label
   additional_tags            = var.additional_tags
   region                     = var.region

--- a/main.tf
+++ b/main.tf
@@ -275,7 +275,7 @@ module "cluster" {
   aws_account_name           = var.aws_account
   oidc_enabled               = false
   source                     = "app.terraform.io/indico/indico-aws-eks-cluster/mod"
-  version                    = "8.0.15"
+  version                    = "8.0.16"
   label                      = var.label
   additional_tags            = var.additional_tags
   region                     = var.region

--- a/main.tf
+++ b/main.tf
@@ -276,7 +276,7 @@ module "cluster" {
   aws_account_name           = var.aws_account
   oidc_enabled               = false
   source                     = "app.terraform.io/indico/indico-aws-eks-cluster/mod"
-  version                    = "8.0.7"
+  version                    = "8.0.8"
   label                      = var.label
   additional_tags            = var.additional_tags
   region                     = var.region

--- a/main.tf
+++ b/main.tf
@@ -275,7 +275,7 @@ module "cluster" {
   aws_account_name           = var.aws_account
   oidc_enabled               = false
   source                     = "app.terraform.io/indico/indico-aws-eks-cluster/mod"
-  version                    = "8.0.14"
+  version                    = "8.0.15"
   label                      = var.label
   additional_tags            = var.additional_tags
   region                     = var.region

--- a/main.tf
+++ b/main.tf
@@ -10,38 +10,39 @@ terraform {
     }
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "4.0.1"
+      version = "4.3.1"
     }
     argocd = {
       source  = "oboukili/argocd"
-      version = "5.4.0"
+      version = "6.0.2"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 2.12.1"
+      version = ">= 2.23.0"
     }
     kubectl = {
-      source = "gavinbunney/kubectl"
+      source  = "gavinbunney/kubectl"
+      version = "1.14.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.6.0"
+      version = ">= 2.11.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~>3.3.0"
+      version = "~>3.5.1"
     }
     github = {
       source  = "integrations/github"
-      version = "4.26.0"
+      version = "5.34.0"
     }
     vault = {
       source  = "hashicorp/vault"
-      version = "3.13.0"
+      version = "3.19.0"
     }
     snowflake = {
       source  = "Snowflake-Labs/snowflake"
-      version = "~> 0.35"
+      version = "~> 0.70"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -269,18 +269,16 @@ module "fsx-storage" {
   include_rox                 = var.include_rox
 }
 
-
 module "cluster" {
   cod_snapshots_enabled      = true
   allow_dns_management       = true
   aws_account_name           = var.aws_account
   oidc_enabled               = false
   source                     = "app.terraform.io/indico/indico-aws-eks-cluster/mod"
-  version                    = "8.0.13"
+  version                    = "8.0.14"
   label                      = var.label
   additional_tags            = var.additional_tags
   region                     = var.region
-  map_roles                  = [{ rolearn = module.cluster-manager.cluster_manager_iam_role_arn, username = "admin", groups = ["system:masters"] }]
   map_users                  = values(local.eks_users)
   vpc_id                     = local.network[0].indico_vpc_id
   security_group_id          = module.security-group.all_subnets_sg_id
@@ -301,7 +299,6 @@ module "cluster" {
   access_security_group      = module.cluster-manager.cluster_manager_sg
   aws_primary_dns_role_arn   = var.aws_primary_dns_role_arn
 }
-
 
 module "readapi" {
   count = var.enable_readapi ? 1 : 0

--- a/main.tf
+++ b/main.tf
@@ -276,7 +276,7 @@ module "cluster" {
   aws_account_name           = var.aws_account
   oidc_enabled               = false
   source                     = "app.terraform.io/indico/indico-aws-eks-cluster/mod"
-  version                    = "8.0.12"
+  version                    = "8.0.13"
   label                      = var.label
   additional_tags            = var.additional_tags
   region                     = var.region

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ terraform {
     }
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "4.3.1"
+      version = "4.0.1"
     }
     argocd = {
       source  = "oboukili/argocd"

--- a/main.tf
+++ b/main.tf
@@ -276,7 +276,7 @@ module "cluster" {
   aws_account_name           = var.aws_account
   oidc_enabled               = false
   source                     = "app.terraform.io/indico/indico-aws-eks-cluster/mod"
-  version                    = "8.0.11"
+  version                    = "8.0.12"
   label                      = var.label
   additional_tags            = var.additional_tags
   region                     = var.region

--- a/main.tf
+++ b/main.tf
@@ -161,23 +161,6 @@ module "sqs_sns" {
   label   = var.label
 }
 
-module "cluster-manager" {
-  source                   = "app.terraform.io/indico/indico-aws-cluster-manager/mod"
-  version                  = "1.1.1"
-  label                    = var.label
-  additional_tags          = var.additional_tags
-  vpc_id                   = local.network[0].indico_vpc_id
-  subnet_id                = var.direct_connect == true ? local.network[0].private_subnet_ids[0] : local.network[0].public_subnet_ids[0]
-  user_ip                  = var.user_ip
-  key_pair                 = aws_key_pair.kp.key_name
-  public_ip                = !var.direct_connect # if using direct connect setup, do not provision public ip
-  region                   = var.region
-  cluster_name             = var.cluster_name
-  cluster_manager_iam_role = var.cluster_manager_iam_role
-  kms_key_arn              = module.kms_key.key_arn
-  assumed_roles            = var.assumed_roles
-}
-
 module "kms_key" {
   source           = "app.terraform.io/indico/indico-aws-kms/mod"
   version          = "2.0.2"
@@ -275,7 +258,7 @@ module "cluster" {
   aws_account_name           = var.aws_account
   oidc_enabled               = false
   source                     = "app.terraform.io/indico/indico-aws-eks-cluster/mod"
-  version                    = "8.0.17"
+  version                    = "8.0.19"
   label                      = var.label
   additional_tags            = var.additional_tags
   region                     = var.region
@@ -296,7 +279,6 @@ module "cluster" {
   s3_buckets                 = [module.s3-storage.data_s3_bucket_name, var.include_pgbackup ? module.s3-storage.pgbackup_s3_bucket_name : "", var.include_rox ? module.s3-storage.api_models_s3_bucket_name : "", lower("${var.aws_account}-aws-cod-snapshots"), var.performance_bucket ? "indico-locust-benchmark-test-results" : ""]
   cluster_version            = var.cluster_version
   efs_filesystem_id          = [var.include_efs == true ? module.efs-storage[0].efs_filesystem_id : ""]
-  access_security_group      = module.cluster-manager.cluster_manager_sg
   aws_primary_dns_role_arn   = var.aws_primary_dns_role_arn
 }
 

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ terraform {
     }
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "4.0.1"
+      version = "4.3.1"
     }
     argocd = {
       source  = "oboukili/argocd"

--- a/main.tf
+++ b/main.tf
@@ -276,7 +276,7 @@ module "cluster" {
   aws_account_name           = var.aws_account
   oidc_enabled               = false
   source                     = "app.terraform.io/indico/indico-aws-eks-cluster/mod"
-  version                    = "8.0.2"
+  version                    = "8.0.3"
   label                      = var.label
   additional_tags            = var.additional_tags
   region                     = var.region

--- a/main.tf
+++ b/main.tf
@@ -276,7 +276,7 @@ module "cluster" {
   aws_account_name           = var.aws_account
   oidc_enabled               = false
   source                     = "app.terraform.io/indico/indico-aws-eks-cluster/mod"
-  version                    = "8.0.9"
+  version                    = "8.0.10"
   label                      = var.label
   additional_tags            = var.additional_tags
   region                     = var.region

--- a/main.tf
+++ b/main.tf
@@ -276,7 +276,7 @@ module "cluster" {
   aws_account_name           = var.aws_account
   oidc_enabled               = false
   source                     = "app.terraform.io/indico/indico-aws-eks-cluster/mod"
-  version                    = "8.0.1"
+  version                    = "8.0.2"
   label                      = var.label
   additional_tags            = var.additional_tags
   region                     = var.region

--- a/main.tf
+++ b/main.tf
@@ -276,7 +276,7 @@ module "cluster" {
   aws_account_name           = var.aws_account
   oidc_enabled               = false
   source                     = "app.terraform.io/indico/indico-aws-eks-cluster/mod"
-  version                    = "8.0.8"
+  version                    = "8.0.9"
   label                      = var.label
   additional_tags            = var.additional_tags
   region                     = var.region

--- a/main.tf
+++ b/main.tf
@@ -276,7 +276,7 @@ module "cluster" {
   aws_account_name           = var.aws_account
   oidc_enabled               = false
   source                     = "app.terraform.io/indico/indico-aws-eks-cluster/mod"
-  version                    = "8.0.6"
+  version                    = "8.0.7"
   label                      = var.label
   additional_tags            = var.additional_tags
   region                     = var.region

--- a/main.tf
+++ b/main.tf
@@ -276,7 +276,7 @@ module "cluster" {
   aws_account_name           = var.aws_account
   oidc_enabled               = false
   source                     = "app.terraform.io/indico/indico-aws-eks-cluster/mod"
-  version                    = "8.0.10"
+  version                    = "8.0.11"
   label                      = var.label
   additional_tags            = var.additional_tags
   region                     = var.region

--- a/modules/aws/keycloak/keycloak.tf
+++ b/modules/aws/keycloak/keycloak.tf
@@ -2,11 +2,9 @@ terraform {
   required_providers {
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "4.0.1"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.6.0"
     }
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,12 +8,6 @@ output "data_s3_bucket_name" {
   description = "Name of the data s3 bucket"
   value       = module.s3-storage.data_s3_bucket_name
 }
-/*
-output "cluster_manager_ip" {
-  description = "IP of the cluster manager instance"
-  value       = module.cluster-manager.cluster_manager_ip
-}
-*/
 
 output "s3_role_id" {
   description = "ID of the S3 role"

--- a/user_vars.auto.tfvars
+++ b/user_vars.auto.tfvars
@@ -95,7 +95,6 @@ default_tags = {
   "indico/cluster"     = "dop-832",    #This should match the label variable
   "indico/environment" = "dev"         # Choices are dev , stage , prod
 }
-user_ip           = "" # set this to the external IP address if deployment server has no outbound access; else, leave as empty string or remove
 submission_expiry = 30 # days
 uploads_expiry    = 30 # days
 #RDS Stuff
@@ -108,8 +107,3 @@ include_fsx                 = false
 include_efs                 = true
 #cluster
 node_group_multi_az = false
-assumed_roles = [
-  "arn:aws:iam::528987135818:role/aws-reserved/sso.amazonaws.com/us-east-2/AWSReservedSSO_SupportUser_e2021891b05267dd",
-  "arn:aws:iam::528987135818:role/aws-reserved/sso.amazonaws.com/us-east-2/AWSReservedSSO_PowerUserAccess_d162cafa6627ab76",
-  "arn:aws:iam::528987135818:role/aws-reserved/sso.amazonaws.com/us-east-2/AWSReservedSSO_AdministratorAccess_e837eb0d7af593bc"
-]

--- a/variables.tf
+++ b/variables.tf
@@ -90,13 +90,6 @@ variable "public_ip" {
   description = "Should the cluster manager have a public IP assigned"
 }
 
-variable "user_ip" {
-  type        = string
-  default     = ""
-  description = "The IP address to allow SSH access for"
-}
-
-
 variable "vpc_name" {
   type        = string
   default     = "indico_vpc"
@@ -224,12 +217,6 @@ variable "azure_indico_io_tenant_id" {
 }
 
 # IAM
-variable "cluster_manager_iam_role" {
-  type        = string
-  default     = null
-  description = "Name of the IAM role to assign to the cluster manager EC2 instance; will be created if not supplied"
-}
-
 variable "eks_cluster_iam_role" {
   type        = string
   default     = null
@@ -282,12 +269,6 @@ variable "include_rox" {
   type        = bool
   default     = false
   description = "Create a read only FSx file system"
-}
-
-variable "assumed_roles" {
-  type        = list(string)
-  default     = null
-  description = "list of ARNs to be put in the trust relationship for the cluster manager role"
 }
 
 variable "aws_account" {

--- a/variables.tf
+++ b/variables.tf
@@ -468,7 +468,7 @@ variable "hibernation_enabled" {
 }
 
 variable "keda_version" {
-  default = "2.8.1"
+  default = "2.11.2"
 }
 
 variable "opentelemetry-collector_version" {


### PR DESCRIPTION
Ended up removing the cluster manager to simplify the way that the aws-auth configmap was managed through the eks module