### PR TITLE
[DOP-1986] Use SQL-exporter instead of postgres-exporter

### DIFF
--- a/azure/ipa.tf
+++ b/azure/ipa.tf
@@ -1024,3 +1024,21 @@ spec:
 EOT
 }
 
+resource "helm_release" "external-secrets" {
+  depends_on = [
+    module.cluster,
+    data.github_repository_file.data-crds-values,
+    module.secrets-operator-setup
+  ]
+
+
+  verify           = false
+  name             = "external-secrets"
+  create_namespace = true
+  namespace        = "default"
+  repository       = "https://charts.external-secrets.io/"
+  chart            = "external-secrets"
+  version          = var.external_secrets_version
+  wait             = true
+
+}

--- a/azure/ipa.tf
+++ b/azure/ipa.tf
@@ -255,7 +255,8 @@ resource "null_resource" "wait-for-tf-cod-chart-build" {
 resource "helm_release" "terraform-smoketests" {
   depends_on = [
     null_resource.wait-for-tf-cod-chart-build,
-    kubernetes_config_map.terraform-variables
+    kubernetes_config_map.terraform-variables,
+    helm_release.monitoring
   ]
 
   verify           = false

--- a/azure/ipa.tf
+++ b/azure/ipa.tf
@@ -275,7 +275,7 @@ resource "helm_release" "terraform-smoketests" {
     region: ${var.region}
     name: ${var.label}
   image:
-    tag: ${substr(data.external.git_information.result.sha, 0, 8)}
+    tag: "${substr(data.external.git_information.result.sha, 0, 8)}"
   EOF
   ]
 }

--- a/azure/tf-smoketest-variables.tf
+++ b/azure/tf-smoketest-variables.tf
@@ -47,6 +47,7 @@ resource "kubernetes_config_map" "terraform-variables" {
     restore_snapshot_name = "${jsonencode(var.restore_snapshot_name)}"
     monitoring_enabled = "${jsonencode(var.monitoring_enabled)}"
     keda_version = "${jsonencode(var.keda_version)}"
+    external_secrets_version = "${jsonencode(var.external_secrets_version)}"
     opentelemetry_collector_version = "${jsonencode(var.opentelemetry-collector_version)}"
     ipa_smoketest_values = "${jsonencode(var.ipa_smoketest_values)}"
     ipa_smoketest_repo = "${jsonencode(var.ipa_smoketest_repo)}"

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -311,6 +311,12 @@ variable "keda_version" {
   description = "Version of keda helm chart"
 }
 
+variable "external_secrets_version" {
+  type    = string
+  default = "0.9.9"
+  description = "Version of external-secrets helm chart"
+}
+
 variable "opentelemetry-collector_version" {
   type        = string
   default     = "0.30.0"

--- a/ipa.tf
+++ b/ipa.tf
@@ -813,7 +813,7 @@ resource "helm_release" "terraform-smoketests" {
     region: ${var.region}
     name: ${var.label}
   image:
-    tag: ${substr(data.external.git_information.result.sha, 0, 8)}
+    tag: "${substr(data.external.git_information.result.sha, 0, 8)}"
   EOF
   ]
 }

--- a/ipa.tf
+++ b/ipa.tf
@@ -793,7 +793,8 @@ resource "helm_release" "terraform-smoketests" {
   depends_on = [
     null_resource.wait-for-tf-cod-chart-build,
     #null_resource.sleep-5-minutes-wait-for-charts-smoketest-build,
-    kubernetes_config_map.terraform-variables
+    kubernetes_config_map.terraform-variables,
+    helm_release.monitoring
   ]
 
   verify           = false

--- a/ipa.tf
+++ b/ipa.tf
@@ -310,6 +310,7 @@ module "secrets-operator-setup" {
   kubernetes_host = module.cluster.kubernetes_host
 }
 
+
 resource "helm_release" "ipa-vso" {
   count = var.thanos_enabled == true ? 1 : 0
   depends_on = [
@@ -373,6 +374,26 @@ resource "helm_release" "ipa-vso" {
 EOF
   ]
 }
+
+resource "helm_release" "external-secrets" {
+  depends_on = [
+    module.cluster,
+    data.github_repository_file.data-crds-values,
+    module.secrets-operator-setup
+  ]
+
+
+  verify           = false
+  name             = "external-secrets"
+  create_namespace = true
+  namespace        = "default"
+  repository       = "https://charts.external-secrets.io/"
+  chart            = "external-secrets"
+  version          = var.external_secrets_version
+  wait             = true
+
+}
+
 
 resource "helm_release" "ipa-crds" {
   depends_on = [

--- a/monitoring.tf
+++ b/monitoring.tf
@@ -206,6 +206,7 @@ resource "helm_release" "monitoring" {
   depends_on = [
     module.cluster,
     helm_release.ipa-pre-requisites,
+    helm_release.external-secrets,
     aws_route53_record.alertmanager-caa,
     aws_route53_record.grafana-caa,
     aws_route53_record.prometheus-caa,

--- a/smoketests/common/test_common.py
+++ b/smoketests/common/test_common.py
@@ -23,6 +23,12 @@ class TestCommon:
         print(
             f"\nTeardown method called using {cloudProvider} {account}/{region}/{name}\n")
 
+    def test_external_secrets_operator(self, cloudProvider, account, region, name):
+        p = Process(account, region, name)
+        output = p.run(["kubectl", "get", "secret", "-n",
+                       "monitoring", "sql-exporter-dsn"], stdout=subprocess.PIPE)
+        assert output.returncode == 0, f"Unable to get External Generated Secret sql-exporter-dsn : {output.stderr}"
+
     # validate that the vault-secrets-operator is able to make secrets
 
     def test_vault_secrets_operator(self, cloudProvider, account, region, name):

--- a/tf-smoketest-variables.tf
+++ b/tf-smoketest-variables.tf
@@ -87,6 +87,7 @@ resource "kubernetes_config_map" "terraform-variables" {
     monitoring_enabled = "${jsonencode(var.monitoring_enabled)}"
     hibernation_enabled = "${jsonencode(var.hibernation_enabled)}"
     keda_version = "${jsonencode(var.keda_version)}"
+    external_secrets_version = "${jsonencode(var.external_secrets_version)}"
     opentelemetry_collector_version = "${jsonencode(var.opentelemetry-collector_version)}"
     include_fsx = "${jsonencode(var.include_fsx)}"
     include_pgbackup = "${jsonencode(var.include_pgbackup)}"

--- a/variables.tf
+++ b/variables.tf
@@ -503,6 +503,12 @@ variable "keda_version" {
   default = "2.11.2"
 }
 
+variable "external_secrets_version" {
+  type    = string
+  default = "0.9.9"
+  description = "Version of external-secrets helm chart"
+}
+
 variable "opentelemetry-collector_version" {
   default = "0.30.0"
 }


### PR DESCRIPTION
This now installs the external-secret operators helm chart. -https://external-secrets.io/latest/