### PR TITLE
[DOP-2234] Enable s3 VPC Gateway endpoint by default.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -49,7 +49,7 @@ terraform {
       version = "1.0.4"
     }
     azurerm = {
-      source = "hashicorp/azurerm"
+      source  = "hashicorp/azurerm"
       version = "3.95.0"
     }
   }
@@ -175,6 +175,8 @@ module "public_networking" {
   private_subnet_cidrs = var.private_subnet_cidrs
   public_subnet_cidrs  = var.public_subnet_cidrs
   subnet_az_zones      = var.subnet_az_zones
+  region               = var.region
+  s3_endpoint_enabled  = var.s3_endpoint_enabled
 }
 
 module "private_networking" {

--- a/tf-smoketest-variables.tf
+++ b/tf-smoketest-variables.tf
@@ -141,6 +141,7 @@ resource "kubernetes_config_map" "terraform-variables" {
     harness_delegate_replicas = "${jsonencode(var.harness_delegate_replicas)}"
     harness_mount_path = "${jsonencode(var.harness_mount_path)}"
     enable_s3_backup = "${jsonencode(var.enable_s3_backup)}"
+    s3_endpoint_enabled = "${jsonencode(var.s3_endpoint_enabled)}"
 
     }
   }

--- a/user_vars.auto.tfvars
+++ b/user_vars.auto.tfvars
@@ -107,3 +107,4 @@ include_fsx                 = false
 include_efs                 = true
 #cluster
 az_count = 2
+s3_endpoint_enabled = true

--- a/variables.tf
+++ b/variables.tf
@@ -839,3 +839,9 @@ variable "enable_s3_backup" {
   default     = true
   description = "Allow backing up data bucket on s3"
 }
+
+variable "s3_endpoint_enabled" {
+  type        = bool
+  default     = false
+  description = "If set to true, an S3 VPC endpoint will be created. If this variable is set, the `region` variable must also be set"
+}


### PR DESCRIPTION
This is a cost savings measure because it keeps traffic bound for s3 from traversing the NAT gateway. Instead it is able to go from the private subnets directly to s3 with no additional charge.