### PR TITLE
[dop-2213] Update eks module to Reduce node root volume from 100Gi to 40Gi

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -307,7 +307,7 @@ module "cluster" {
   aws_account_name           = var.aws_account
   oidc_enabled               = false
   source                     = "app.terraform.io/indico/indico-aws-eks-cluster/mod"
-  version                    = "8.1.7"
+  version                    = "8.1.8"
   label                      = var.label
   additional_tags            = var.additional_tags
   region                     = var.region


### PR DESCRIPTION
This is based on data from [https://grafana.monitoring.us-east-2.indico-devops.indico.io/d/e0f85123-8af1-41ae-9d32-a5078e9ffffc/nod[…]&var-cluster_name=All&var-account_name=wrb](https://grafana.monitoring.us-east-2.indico-devops.indico.io/d/e0f85123-8af1-41ae-9d32-a5078e9ffffc/node-volume-usage?orgId=1&var-cluster_name=All&var-account_name=wrb) which shows that the majority of our clusters use less than 30% of their volumes.

Testing performed:
- Spun up a cod cluster with this version and IPA-6.8.1 and validated smoketests pass
- Spun up a cod cluster with IPA-6.8.1 and validated that smoketests pass., Then updated cluster to this version and verified that the cluster and nodes all updated. After everything settled the smoketests passed again. Please note, it took about 40 minutes for everything to settle.
