### PR TITLE
[DEV-11744] Fix for failing migration jobs

### DIFF
--- a/ipa.tf
+++ b/ipa.tf
@@ -485,11 +485,9 @@ resource "helm_release" "ipa-crds" {
   migrations-operator:
     image:
       repository: ${var.image_registry}/indico/migrations-operator
-      tag: "3.0.13"
     controllerImage:
       repository: ${var.image_registry}/indico/migrations-controller
       kubectlImage: ${var.image_registry}/indico/migrations-controller-kubectl
-      tag: "3.0.12"
   aws-ebs-csi-driver:
     image:
       repository: ${var.image_registry}/public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver


### PR DESCRIPTION
Remove tag override in migration-operator so that it will default to the tag specified in charts.