### PR TITLE
[DOP-2338] Terraform helm provider update to 2.15.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.11.0"
+      version = ">= 2.15.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.15.0"
+      version = "2.15.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/harness/versions.tf
+++ b/modules/harness/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     helm = {
       source  = "hashicorp/helm"
-      version = "2.11.0"
+      version = "2.15.0"
     }
     utils = {
       source  = "cloudposse/utils"


### PR DESCRIPTION
This is to fix an intermittent issue where terraform cloud crashes due to the helm provider.