### PR TITLE
[DOP-2338] adjust pinned helm provider version

### DIFF
--- a/azure/main.tf
+++ b/azure/main.tf
@@ -21,7 +21,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.6.0"
+      version = "2.15.0"
     }
     argocd = {
       source  = "oboukili/argocd"

--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.11.0"
+      version = "2.15.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/harness/versions.tf
+++ b/modules/harness/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     helm = {
       source  = "hashicorp/helm"
-      version = "2.11.0"
+      version = "2.15.0"
     }
     utils = {
       source  = "cloudposse/utils"

--- a/modules/harness/versions.tf
+++ b/modules/harness/versions.tf
@@ -2,7 +2,6 @@ terraform {
   required_providers {
     helm = {
       source  = "hashicorp/helm"
-      version = "2.15.0"
     }
     utils = {
       source  = "cloudposse/utils"


### PR DESCRIPTION
This is to fix an intermittent issue with terraform cloud crashes caused by the helm provider version.