### PR TITLE
[dop-2360] Fix security group reference.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -179,7 +179,7 @@ module "lambda-sns-forwarder" {
   region               = var.region
   label                = var.label
   subnet_ids           = flatten([local.network[0].private_subnet_ids])
-  security_group_id    = var.network_module == "networking" ? module.networking.all_subnets_sg_id : module.security-group.all_subnets_sg_id
+  security_group_id    = var.network_module == "networking" ? local.network[0].all_subnets_sg_id : module.security-group.all_subnets_sg_id
   kms_key              = module.kms_key.key_arn
   sns_arn              = var.lambda_sns_forwarder_topic_arn == "" ? module.sqs_sns[0].indico_ipa_topic_arn : var.lambda_sns_forwarder_topic_arn
   destination_endpoint = var.lambda_sns_forwarder_destination_endpoint


### PR DESCRIPTION
This is to fix the terraform error:
Error: Unsupported attribute
on main.tf line 180, in module "lambda-sns-forwarder":
  security_group_id    = var.network_module == "networking" ? module.networking.all_subnets_sg_id : module.security-group.all_subnets_sg_id
module.networking is tuple with 1 element
This value does not have any attributes.