### PR TITLE
[DEV-12943] Fix the rolebindings to point to new group names

### DIFF
--- a/oidc.tf
+++ b/oidc.tf
@@ -30,19 +30,19 @@ resource "kubernetes_cluster_role_binding" "cod-role-bindings" {
 
   subject {
     kind      = "Group"
-    name      = "oidcgroup:Engineering"
+    name      = "oidcgroup:engineering@indico.io"
     api_group = "rbac.authorization.k8s.io"
   }
 
   subject {
     kind      = "Group"
-    name      = "oidcgroup:QA"
+    name      = "oidcgroup:qa@indico.io"
     api_group = "rbac.authorization.k8s.io"
   }
 
   subject {
     kind      = "Group"
-    name      = "oidcgroup:DevOps"
+    name      = "oidcgroup:devops@indico.io"
     api_group = "rbac.authorization.k8s.io"
   }
 }
@@ -67,13 +67,13 @@ resource "kubernetes_cluster_role_binding" "eng-qa-rbac-bindings" {
 
   subject {
     kind      = "Group"
-    name      = "oidcgroup:Engineering"
+    name      = "oidcgroup:engineering@indico.io"
     api_group = "rbac.authorization.k8s.io"
   }
 
   subject {
     kind      = "Group"
-    name      = "oidcgroup:QA"
+    name      = "oidcgroup:qa@indico.io"
     api_group = "rbac.authorization.k8s.io"
   }
 }
@@ -98,7 +98,7 @@ resource "kubernetes_cluster_role_binding" "devops-rbac-bindings" {
 
   subject {
     kind      = "Group"
-    name      = "oidcgroup:DevOps"
+    name      = "oidcgroup:devops@indico.io"
     api_group = "rbac.authorization.k8s.io"
   }
 }


### PR DESCRIPTION
The old groups still exist so we didn't see this issue when I reimplemented keycloak group automation in the summer.

This will fix the group names to match what is currently up to date in keycloak. We should also take a closer look at the logic for the rolebindings here, it looks like engineering might have admin access to devops clusters. 