### PR TITLE
Improvements to harness delegate

### DIFF
--- a/azure/harness.tf
+++ b/azure/harness.tf
@@ -11,10 +11,10 @@ module "harness_delegate" {
   delegate_token   = jsondecode(data.vault_kv_secret_v2.delegate_secrets[0].data_json)["DELEGATE_TOKEN"]
   delegate_name    = "${var.label}-harness-delegate"
   namespace        = "harness-delegate-ng"
-  manager_endpoint = "https://app.harness.io/gratis"
+  manager_endpoint = "https://app.harness.io"
   delegate_image   = jsondecode(data.vault_kv_secret_v2.delegate_secrets[0].data_json)["DELEGATE_IMAGE"]
   replicas         = 1
-  upgrader_enabled = false
+  upgrader_enabled = true
 
   # Additional optional values to pass to the helm chart
   values = yamlencode({

--- a/azure/harness.tf
+++ b/azure/harness.tf
@@ -11,7 +11,7 @@ module "harness_delegate" {
   delegate_token   = jsondecode(data.vault_kv_secret_v2.delegate_secrets[0].data_json)["DELEGATE_TOKEN"]
   delegate_name    = "${var.label}-harness-delegate"
   namespace        = "harness-delegate-ng"
-  manager_endpoint = "https://app.harness.io"
+  manager_endpoint = "https://app.harness.io/gratis"
   delegate_image   = jsondecode(data.vault_kv_secret_v2.delegate_secrets[0].data_json)["DELEGATE_IMAGE"]
   replicas         = 1
   upgrader_enabled = true

--- a/azure/harness.tf
+++ b/azure/harness.tf
@@ -13,7 +13,6 @@ module "harness_delegate" {
   namespace        = "harness-delegate-ng"
   manager_endpoint = "https://app.harness.io/gratis"
   delegate_image   = jsondecode(data.vault_kv_secret_v2.delegate_secrets[0].data_json)["DELEGATE_IMAGE"]
-  replicas         = 1
   upgrader_enabled = true
 
   # Additional optional values to pass to the helm chart

--- a/harness.tf
+++ b/harness.tf
@@ -12,10 +12,10 @@ module "harness_delegate" {
   delegate_token   = jsondecode(data.vault_kv_secret_v2.delegate_secrets[0].data_json)["DELEGATE_TOKEN"]
   delegate_name    = "${var.cluster_name}-harness-delegate"
   namespace        = "harness-delegate-ng"
-  manager_endpoint = "https://app.harness.io/gratis"
+  manager_endpoint = "https://app.harness.io"
   delegate_image   = jsondecode(data.vault_kv_secret_v2.delegate_secrets[0].data_json)["DELEGATE_IMAGE"]
   replicas         = var.harness_delegate_replicas
-  upgrader_enabled = false
+  upgrader_enabled = true
 
   # Additional optional values to pass to the helm chart
   values = yamlencode({

--- a/harness.tf
+++ b/harness.tf
@@ -3,7 +3,8 @@ module "harness_delegate" {
 
   depends_on = [
     module.cluster,
-    time_sleep.wait_1_minutes_after_cluster
+    time_sleep.wait_1_minutes_after_cluster,
+    module.indico-common
   ]
 
   source = "./modules/harness"

--- a/harness.tf
+++ b/harness.tf
@@ -14,7 +14,6 @@ module "harness_delegate" {
   namespace        = "harness-delegate-ng"
   manager_endpoint = "https://app.harness.io/gratis"
   delegate_image   = jsondecode(data.vault_kv_secret_v2.delegate_secrets[0].data_json)["DELEGATE_IMAGE"]
-  replicas         = var.harness_delegate_replicas
   upgrader_enabled = true
 
   # Additional optional values to pass to the helm chart

--- a/harness.tf
+++ b/harness.tf
@@ -12,7 +12,7 @@ module "harness_delegate" {
   delegate_token   = jsondecode(data.vault_kv_secret_v2.delegate_secrets[0].data_json)["DELEGATE_TOKEN"]
   delegate_name    = "${var.cluster_name}-harness-delegate"
   namespace        = "harness-delegate-ng"
-  manager_endpoint = "https://app.harness.io"
+  manager_endpoint = "https://app.harness.io/gratis"
   delegate_image   = jsondecode(data.vault_kv_secret_v2.delegate_secrets[0].data_json)["DELEGATE_IMAGE"]
   replicas         = var.harness_delegate_replicas
   upgrader_enabled = true

--- a/modules/harness/main.tf
+++ b/modules/harness/main.tf
@@ -38,27 +38,6 @@ locals {
     delegateAnnotations = {
       "cluster-autoscaler.kubernetes.io/safe-to-evict" : "false"
     }
-    affinity = {
-      podAntiAffinity = {
-        preferredDuringSchedulingIgnoredDuringExecution = [
-          {
-            weight = 100
-            podAffinityTerm = {
-              labelSelector = {
-                matchExpressions = [
-                  {
-                    key      = "app.kubernetes.io/name"
-                    operator = "Contains"
-                    values   = ["harness-delegate"]
-                  }
-                ]
-              }
-              topologyKey = "kubernetes.io/hostname"
-            }
-          }
-        ]
-      }
-    }
   })
 }
 

--- a/modules/harness/main.tf
+++ b/modules/harness/main.tf
@@ -38,6 +38,27 @@ locals {
     delegateAnnotations = {
       "cluster-autoscaler.kubernetes.io/safe-to-evict" : "false"
     }
+    affinity = {
+      podAntiAffinity = {
+        preferredDuringSchedulingIgnoredDuringExecution = [
+          {
+            weight = 100
+            podAffinityTerm = {
+              labelSelector = {
+                matchExpressions = [
+                  {
+                    key      = "app.kubernetes.io/name"
+                    operator = "Contains"
+                    values   = ["harness-delegate"]
+                  }
+                ]
+              }
+              topologyKey = "kubernetes.io/hostname"
+            }
+          }
+        ]
+      }
+    }
   })
 }
 

--- a/modules/harness/main.tf
+++ b/modules/harness/main.tf
@@ -31,8 +31,8 @@ locals {
     memory              = 4096,
     autoscaling = {
       enabled                           = true,
-      min                               = 2,
-      max                               = 4,
+      minReplicas                       = 2,
+      maxReplicas                       = 4,
       targetMemoryUtilizationPercentage = 80
     }
     delegateAnnotations = {

--- a/modules/harness/main.tf
+++ b/modules/harness/main.tf
@@ -35,6 +35,9 @@ locals {
       max                               = 4,
       targetMemoryUtilizationPercentage = 80
     }
+    delegateAnnotations = {
+      "cluster-autoscaler.kubernetes.io/safe-to-evict" : "false"
+    }
   })
 }
 

--- a/modules/harness/main.tf
+++ b/modules/harness/main.tf
@@ -17,7 +17,6 @@ locals {
     namespace           = var.namespace,
     delegateName        = var.delegate_name,
     delegateDockerImage = var.delegate_image,
-    replicas            = var.replicas,
     upgrader            = { enabled = var.upgrader_enabled }
     nextGen             = var.next_gen,
     proxyUser           = var.proxy_user,
@@ -27,7 +26,15 @@ locals {
     proxyScheme         = var.proxy_scheme,
     noProxy             = var.no_proxy,
     initScript          = var.init_script,
-    deployMode          = var.deploy_mode
+    deployMode          = var.deploy_mode,
+    cpu                 = 2,
+    memory              = 4096,
+    autoscaling = {
+      enabled                           = true,
+      min                               = 1,
+      max                               = 4,
+      targetMemoryUtilizationPercentage = 80
+    }
   })
 }
 

--- a/modules/harness/main.tf
+++ b/modules/harness/main.tf
@@ -31,12 +31,33 @@ locals {
     memory              = 4096,
     autoscaling = {
       enabled                           = true,
-      min                               = 1,
+      min                               = 2,
       max                               = 4,
       targetMemoryUtilizationPercentage = 80
     }
     delegateAnnotations = {
       "cluster-autoscaler.kubernetes.io/safe-to-evict" : "false"
+    }
+    affinity = {
+      podAntiAffinity = {
+        preferredDuringSchedulingIgnoredDuringExecution = [
+          {
+            weight = 100
+            podAffinityTerm = {
+              labelSelector = {
+                matchExpressions = [
+                  {
+                    key      = "app.kubernetes.io/name"
+                    operator = "In"
+                    values   = [var.delegate_name]
+                  }
+                ]
+              }
+              topologyKey = "kubernetes.io/hostname"
+            }
+          }
+        ]
+      }
     }
   })
 }

--- a/modules/harness/main.tf
+++ b/modules/harness/main.tf
@@ -2,6 +2,7 @@ resource "helm_release" "delegate" {
   name             = var.delegate_name
   repository       = var.helm_repository
   chart            = "harness-delegate-ng"
+  version          = var.delegate_version
   namespace        = var.namespace
   create_namespace = var.create_namespace
 
@@ -10,23 +11,23 @@ resource "helm_release" "delegate" {
 
 locals {
   values = yamlencode({
-    accountId            = var.account_id,
-    delegateToken        = var.delegate_token,
-    managerEndpoint      = var.manager_endpoint,
-    namespace            = var.namespace,
-    delegateName         = var.delegate_name,
-    delegateDockerImage  = var.delegate_image,
-    replicas             = var.replicas,
-    upgrader             = { enabled = var.upgrader_enabled }
-    nextGen              = var.next_gen,
-    proxyUser            = var.proxy_user,
-    proxyPassword        = var.proxy_password,
-    proxyHost            = var.proxy_host,
-    proxyPort            = var.proxy_port,
-    proxyScheme          = var.proxy_scheme,
-    noProxy              = var.no_proxy,
-    initScript           = var.init_script,
-    deployMode           = var.deploy_mode
+    accountId           = var.account_id,
+    delegateToken       = var.delegate_token,
+    managerEndpoint     = var.manager_endpoint,
+    namespace           = var.namespace,
+    delegateName        = var.delegate_name,
+    delegateDockerImage = var.delegate_image,
+    replicas            = var.replicas,
+    upgrader            = { enabled = var.upgrader_enabled }
+    nextGen             = var.next_gen,
+    proxyUser           = var.proxy_user,
+    proxyPassword       = var.proxy_password,
+    proxyHost           = var.proxy_host,
+    proxyPort           = var.proxy_port,
+    proxyScheme         = var.proxy_scheme,
+    noProxy             = var.no_proxy,
+    initScript          = var.init_script,
+    deployMode          = var.deploy_mode
   })
 }
 

--- a/modules/harness/variables.tf
+++ b/modules/harness/variables.tf
@@ -10,6 +10,12 @@ variable "helm_repository" {
   default     = "https://app.harness.io/storage/harness-download/delegate-helm-chart/"
 }
 
+variable "delegate_version" {
+  description = "The version of the Harness delegate to use."
+  type        = string
+  default     = "1.0.23"
+}
+
 variable "namespace" {
   description = "The namespace to deploy the Harness delegate to."
   type        = string
@@ -72,14 +78,14 @@ variable "proxy_user" {
   description = "The proxy user to use for the Harness delegate."
   type        = string
   // sensitive = true
-  default     = ""
+  default = ""
 }
 
 variable "proxy_password" {
   description = "The proxy password to use for the Harness delegate."
   type        = string
   // sensitive = true
-  default     = ""
+  default = ""
 }
 
 variable "proxy_host" {

--- a/tf-smoketest-variables.tf
+++ b/tf-smoketest-variables.tf
@@ -134,7 +134,6 @@ resource "kubernetes_config_map" "terraform-variables" {
     terraform_smoketests_enabled = "${jsonencode(var.terraform_smoketests_enabled)}"
     on_prem_test = "${jsonencode(var.on_prem_test)}"
     harness_delegate = "${jsonencode(var.harness_delegate)}"
-    harness_delegate_replicas = "${jsonencode(var.harness_delegate_replicas)}"
     harness_mount_path = "${jsonencode(var.harness_mount_path)}"
     lambda_sns_forwarder_enabled = "${jsonencode(var.lambda_sns_forwarder_enabled)}"
     lambda_sns_forwarder_destination_endpoint = "${jsonencode(var.lambda_sns_forwarder_destination_endpoint)}"

--- a/variables.tf
+++ b/variables.tf
@@ -830,11 +830,6 @@ variable "harness_delegate" {
   default = false
 }
 
-variable "harness_delegate_replicas" {
-  type    = number
-  default = 1
-}
-
 variable "harness_mount_path" {
   type    = string
   default = "harness"


### PR DESCRIPTION
Following harness docs we don't need more than two replicas for the amount of nodes and concurrency pipelines that we have. So I enabled the autoscaling with 2 min replicas to keep HA, add the do-not-evict annotation so cluster autoscaler respect the delegate pod and add affinity to keep pods on different nodes (harness recommends not using the same node for two delates, can cause connectivity issues)