### PR TITLE
[DEV-14318] Use default storage class when deploying rabbitmq on Azure.

### DIFF
--- a/azure/application.tf
+++ b/azure/application.tf
@@ -666,6 +666,8 @@ rabbitmq:
       enabled: true
       serviceMonitor:
         enabled: true
+    persistence:
+      storageClass: default
 
 apiModels:
   enabled: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Configure RabbitMQ persistence to use the cluster’s default storage class in Azure deployment values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22f1ee11ea3975955af537e3c7a2265f8fb14e4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->