### PR TITLE
[DEV-14318] Use default storage class when deploying rabbitmq on Azure.

### DIFF
--- a/azure/application.tf
+++ b/azure/application.tf
@@ -666,6 +666,8 @@ rabbitmq:
       enabled: true
       serviceMonitor:
         enabled: true
+    persistence:
+      torageClass: default
 
 apiModels:
   enabled: true

--- a/azure/application.tf
+++ b/azure/application.tf
@@ -667,7 +667,7 @@ rabbitmq:
       serviceMonitor:
         enabled: true
     persistence:
-      torageClass: default
+      storageClass: default
 
 apiModels:
   enabled: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Configure RabbitMQ to use the `default` storage class for persistence in Azure deployment values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0b8343e7c83461ede3927a0f4d0a92cafa245b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->